### PR TITLE
Pro 28528 reduce memory use

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ Plugin settings to be placed in elasticsearch YAML configuration. Keep defaults,
 | repository_swift.allow_caching               | true or false (default). Allow JOSS caching
 | repository_swift.allow_concurrent_io         | true (default) or false. Allow concurrent writes and deletes.
 | repository_swift.delete_timeout_min          | timeout of snapshot deletion in minutes (default 60 min)
-| repository_swift.snapshot_timeout_min        | timeout of taking a snapshot in minutes (default 360 min)
-| repository_swift.short_operation_timeout_s   | timeout for short operations (like writing a small blob, deleting, or listing) in seconds (default 30 s)
 | repository_swift.retry_interval_s            | interval in seconds for retry-until-success-or-timeout pattern in seconds (default 10 s)
+| repository_swift.short_operation_timeout_s   | timeout for short operations (like writing a small blob, deleting, or listing) in seconds (default 30 s)
+| repository_swift.snapshot_timeout_min        | timeout of taking a snapshot in minutes (default 360 min)
+| repository_swift.stream_read                 | true (default) or false. Reduce memory footprint on restore, at the expense of not being able to retry reads on failure.
 
 ## To debug in Eclipse
 Since Swift has logging dependencies you have to be careful about debugging in Eclipse.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Plugin settings to be placed in elasticsearch YAML configuration. Keep defaults,
 | repository_swift.allow_concurrent_io         | true (default) or false. Allow concurrent writes and deletes.
 | repository_swift.delete_timeout_min          | timeout of snapshot deletion in minutes (default 60 min)
 | repository_swift.retry_interval_s            | interval in seconds for retry-until-success-or-timeout pattern in seconds (default 10 s)
+| repository_swift.retry_count                 | number of attempts for retries where timing is impractical (default 3 times)
 | repository_swift.short_operation_timeout_s   | timeout for short operations (like writing a small blob, deleting, or listing) in seconds (default 30 s)
 | repository_swift.snapshot_timeout_min        | timeout of taking a snapshot in minutes (default 360 min)
 | repository_swift.stream_read                 | true (default) or false. Reduce memory footprint on restore, at the expense of not being able to retry reads on failure.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Plugin settings to be placed in elasticsearch YAML configuration. Keep defaults,
 | repository_swift.short_operation_timeout_s   | timeout for short operations (like writing a small blob, deleting, or listing) in seconds (default 30 s)
 | repository_swift.snapshot_timeout_min        | timeout of taking a snapshot in minutes (default 360 min)
 | repository_swift.stream_read                 | true (default) or false. Reduce memory footprint on restore, at the expense of not being able to retry reads on failure.
+| repository_swift.stream_write                | true or false (default). Reduce memory footprint on snapshot, at the expense of not writing concurrently.
 
 ## To debug in Eclipse
 Since Swift has logging dependencies you have to be careful about debugging in Eclipse.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Plugin settings to be placed in elasticsearch YAML configuration. Keep defaults,
 | repository_swift.retry_interval_s            | interval in seconds for retry-until-success-or-timeout pattern in seconds (default 10 s)
 | repository_swift.retry_count                 | number of attempts for retries where timing is impractical (default 3 times)
 | repository_swift.short_operation_timeout_s   | timeout for short operations (like writing a small blob, deleting, or listing) in seconds (default 30 s)
+| repository_swift.long_operation_timeout_s    | timeout for long operations (like writing of multi-Gig data stream) in seconds (default 600 s)
 | repository_swift.snapshot_timeout_min        | timeout of taking a snapshot in minutes (default 360 min)
 | repository_swift.stream_read                 | true (default) or false. Reduce memory footprint on restore, at the expense of not being able to retry reads on failure.
 | repository_swift.stream_write                | true or false (default). Reduce memory footprint on snapshot, at the expense of not writing concurrently.

--- a/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
@@ -74,6 +74,7 @@ public class SwiftRepositoryPlugin extends Plugin implements RepositoryPlugin {
                              SwiftRepository.Swift.SHORT_OPERATION_TIMEOUT_S_SETTING,
                              SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING,
                              SwiftRepository.Swift.ALLOW_CONCURRENT_IO_SETTING,
-                             SwiftRepository.Swift.STREAM_READ_SETTING);
+                             SwiftRepository.Swift.STREAM_READ_SETTING,
+                             SwiftRepository.Swift.STREAM_WRITE_SETTING);
     }
 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
@@ -72,6 +72,7 @@ public class SwiftRepositoryPlugin extends Plugin implements RepositoryPlugin {
                              SwiftRepository.Swift.DELETE_TIMEOUT_MIN_SETTING,
                              SwiftRepository.Swift.SNAPSHOT_TIMEOUT_MIN_SETTING,
                              SwiftRepository.Swift.SHORT_OPERATION_TIMEOUT_S_SETTING,
+                             SwiftRepository.Swift.LONG_OPERATION_TIMEOUT_S_SETTING,
                              SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING,
                              SwiftRepository.Swift.RETRY_COUNT_SETTING,
                              SwiftRepository.Swift.ALLOW_CONCURRENT_IO_SETTING,

--- a/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
@@ -72,7 +72,8 @@ public class SwiftRepositoryPlugin extends Plugin implements RepositoryPlugin {
                              SwiftRepository.Swift.DELETE_TIMEOUT_MIN_SETTING,
                              SwiftRepository.Swift.SNAPSHOT_TIMEOUT_MIN_SETTING,
                              SwiftRepository.Swift.SHORT_OPERATION_TIMEOUT_S_SETTING,
-                             SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING ,
-                             SwiftRepository.Swift.ALLOW_CONCURRENT_IO_SETTING);
+                             SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING,
+                             SwiftRepository.Swift.ALLOW_CONCURRENT_IO_SETTING,
+                             SwiftRepository.Swift.STREAM_READ_SETTING);
     }
 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/SwiftRepositoryPlugin.java
@@ -73,6 +73,7 @@ public class SwiftRepositoryPlugin extends Plugin implements RepositoryPlugin {
                              SwiftRepository.Swift.SNAPSHOT_TIMEOUT_MIN_SETTING,
                              SwiftRepository.Swift.SHORT_OPERATION_TIMEOUT_S_SETTING,
                              SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING,
+                             SwiftRepository.Swift.RETRY_COUNT_SETTING,
                              SwiftRepository.Swift.ALLOW_CONCURRENT_IO_SETTING,
                              SwiftRepository.Swift.STREAM_READ_SETTING,
                              SwiftRepository.Swift.STREAM_WRITE_SETTING);

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
@@ -105,6 +105,10 @@ public class SwiftRepository extends BlobStoreRepository {
         Setting<Boolean> ALLOW_CONCURRENT_IO_SETTING = Setting.boolSetting("repository_swift.allow_concurrent_io",
                 true,
                 Setting.Property.NodeScope);
+
+        Setting<Boolean> STREAM_READ_SETTING = Setting.boolSetting("repository_swift.stream_read",
+                true,
+                Setting.Property.NodeScope);
     }
 
     private static final Logger logger = LogManager.getLogger(SwiftRepository.class);

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
@@ -102,6 +102,10 @@ public class SwiftRepository extends BlobStoreRepository {
                 10,
                 Setting.Property.NodeScope);
 
+        Setting<Integer> RETRY_COUNT_SETTING = Setting.intSetting("repository_swift.retry_count",
+                3,
+                Setting.Property.NodeScope);
+
         Setting<Boolean> ALLOW_CONCURRENT_IO_SETTING = Setting.boolSetting("repository_swift.allow_concurrent_io",
                 true,
                 Setting.Property.NodeScope);

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
@@ -109,6 +109,10 @@ public class SwiftRepository extends BlobStoreRepository {
         Setting<Boolean> STREAM_READ_SETTING = Setting.boolSetting("repository_swift.stream_read",
                 true,
                 Setting.Property.NodeScope);
+
+        Setting<Boolean> STREAM_WRITE_SETTING = Setting.boolSetting("repository_swift.stream_write",
+                false,
+                Setting.Property.NodeScope);
     }
 
     private static final Logger logger = LogManager.getLogger(SwiftRepository.class);

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
@@ -98,6 +98,10 @@ public class SwiftRepository extends BlobStoreRepository {
                 30,
                 Setting.Property.NodeScope);
 
+        Setting<Integer> LONG_OPERATION_TIMEOUT_S_SETTING = Setting.intSetting("repository_swift.long_operation_timeout_s",
+                600,
+                Setting.Property.NodeScope);
+
         Setting<Integer> RETRY_INTERVAL_S_SETTING = Setting.intSetting("repository_swift.retry_interval_s",
                 10,
                 Setting.Property.NodeScope);

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -61,17 +61,6 @@ import java.util.stream.Collectors;
  * Swift's implementation of the AbstractBlobContainer
  */
 public class SwiftBlobContainer extends AbstractBlobContainer {
-    private static class DirectByteArrayOutputStream extends ByteArrayOutputStream {
-        DirectByteArrayOutputStream(int size) {
-            super(size);
-        }
-
-        @Override
-        public synchronized byte[] toByteArray() {
-            return buf;
-        }
-    }
-
     private static final Logger logger = LogManager.getLogger(SwiftBlobContainer.class);
 
     // Our local swift blob store instance
@@ -396,7 +385,13 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         final int streamAllocationSize = sizeHint > 0 ? sizeHint : bufferSize;
         int totalBytesRead = 0;
 
-        try (DirectByteArrayOutputStream baos = new DirectByteArrayOutputStream(streamAllocationSize)) {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(sizeHint > 0 ? sizeHint : bufferSize) {
+                @Override
+                public synchronized byte[] toByteArray() {
+                    return buf;
+                }
+            })
+        {
             int read;
 
             while ((read = in.read(buffer)) != -1) {

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -74,6 +74,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
     private final int retryIntervalS;
     private final int shortOperationTimeoutS;
     private final boolean allowConcurrentIO;
+    private final boolean streamRead;
 
     private final ExecutorService executor;
     private final WithTimeout.Factory withTimeoutFactory;
@@ -103,6 +104,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         blobExistsCheckAllowed = pathString.isEmpty() || !minimizeBlobExistsChecks;
         retryIntervalS = SwiftRepository.Swift.RETRY_INTERVAL_S_SETTING.get(blobStore.getEnvSettings());
         shortOperationTimeoutS = SwiftRepository.Swift.SHORT_OPERATION_TIMEOUT_S_SETTING.get(blobStore.getEnvSettings());
+        streamRead = SwiftRepository.Swift.STREAM_READ_SETTING.get(blobStore.getEnvSettings());
     }
 
     private WithTimeout withTimeout() {

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -333,7 +333,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                         InputStream rawInputStream = storedObject.downloadObjectAsInputStream();
                         int contentLength = (int) storedObject.getContentLength();
                         String objectEtag = storedObject.getEtag();
-                        ByteArrayInputStream objectStream = readAllBytes(rawInputStream, contentLength);
+                        InputStream objectStream = readAllBytes(rawInputStream, contentLength);
                         String dataEtag = DigestUtils.md5Hex(objectStream);
                         objectStream.reset();
 
@@ -371,7 +371,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                           boolean failIfAlreadyExists) throws IOException {
         if (executor != null && allowConcurrentIO) {
             // async execution races against the InputStream closed in the caller. Read all data locally.
-            ByteArrayInputStream capturedStream = readAllBytes(in, -1);
+            InputStream capturedStream = readAllBytes(in, -1);
 
             Future<Void> task = executor.submit(() -> {
                 internalWriteBlob(blobName, capturedStream, failIfAlreadyExists);
@@ -386,7 +386,10 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
     }
 
     // TODO when compiler level is >8, this method can be replaced with in.transferTo() call
-    private ByteArrayInputStream readAllBytes(InputStream in, int sizeHint) throws IOException {
+    private InputStream readAllBytes(InputStream in, int sizeHint) throws IOException {
+        if (in instanceof ByteArrayInputStream){
+            return in;
+        }
         int bufferSize = (int) blobStore.getBufferSizeInBytes();
         final byte[] buffer = new byte[bufferSize];
 

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -375,8 +375,10 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
 
     private InputStream toReentrantStream(String blobName, InputStream in, long sizeHint) throws IOException {
         if (in.markSupported()) {
+            logger.debug("Reusing reentrant stream of class [" + in.getClass().getName() + "]");
             return in;
         }
+        logger.debug("Reading blob ["+ blobName +"], expected size ["+ sizeHint + "] bytes");
 
         int bufferSize = (int) blobStore.getBufferSizeInBytes();
         final byte[] buffer = new byte[bufferSize];

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -425,9 +425,9 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         }
         return new InputStreamWrapperWithDataHash(objectName, object.stream, object.tag){
             @Override
-            public int innerRead() {
+            protected int innerRead(byte[] b, int off, int len) {
                 try {
-                    return withTimeout().timeout(shortOperationTimeoutS, TimeUnit.SECONDS, super::innerRead);
+                    return withTimeout().timeout(shortOperationTimeoutS, TimeUnit.SECONDS, () -> super.innerRead(b, off, len));
                 } catch (Exception e) {
                     throw new BlobStoreException("failure reading from [" + objectName + "]", e);
                 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -313,6 +313,12 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         return keyPath + blobName;
     }
 
+    private static class ObjectInfo {
+        long size;
+        InputStream stream;
+        String tag;
+    }
+
     /**
      * Fetch a given blob into memory, verify etag, and return InputStream.
      * @param blobName The blob name to read
@@ -323,25 +329,27 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         String objectName = buildKey(blobName);
 
         try {
-            return withTimeout().retry(retryIntervalS, shortOperationTimeoutS, TimeUnit.SECONDS, () -> {
-                try {
-                    return SwiftPerms.execThrows(() -> {
+            ObjectInfo object = withTimeout().retry(retryIntervalS, shortOperationTimeoutS, TimeUnit.SECONDS, () ->
+                SwiftPerms.execThrows(() -> {
+                    try {
                         StoredObject storedObject = blobStore.getContainer().getObject(objectName);
-                        InputStream rawInputStream = storedObject.downloadObjectAsInputStream();
-                        String objectEtag = storedObject.getEtag();
+                        ObjectInfo objectInfo = new ObjectInfo();
+                        objectInfo.stream = storedObject.downloadObjectAsInputStream();
+                        objectInfo.size = storedObject.getContentLength();
+                        objectInfo.tag = storedObject.getEtag();
+                        return objectInfo;
+                    } catch (NotFoundException e) {
+                        // this conversion is necessary for tests to pass
+                        String message = "cannot read object [" + objectName + "]";
+                        logger.warn(message);
+                        NoSuchFileException e2 = new NoSuchFileException(message);
+                        e2.initCause(e);
+                        throw e2;
+                    }
+                }));
 
-                        return streamRead ? new InputStreamWrapperWithDataHash(objectName, rawInputStream, objectEtag)
-                                : objectToReentrantStream(objectName, rawInputStream, storedObject.getContentLength(), objectEtag);
-                    });
-                }
-                catch (NotFoundException e) {
-                    String message = "cannot read object [" + objectName + "]";
-                    logger.warn(message);
-                    NoSuchFileException e2 = new NoSuchFileException(message);
-                    e2.initCause(e);
-                    throw e2;
-                }
-            });
+            return streamRead ? new InputStreamWrapperWithDataHash(objectName, object.stream, object.tag)
+                              : objectToReentrantStream(objectName, object.stream, object.size, object.tag);
         }
         catch (IOException | RuntimeException e){
             throw e;
@@ -351,6 +359,14 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         }
     }
 
+    /**
+     * Write blob to Swift
+     * @param blobName blob name
+     * @param in in-memory stream with blob data. Do not rely on it staying open after this call!
+     * @param blobSize blob size
+     * @param failIfAlreadyExists throw exception if blob exists
+     * @throws IOException can be thrown from various operations
+     */
     @Override
     public void writeBlob(final String blobName,
                           final InputStream in,
@@ -358,7 +374,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                           boolean failIfAlreadyExists) throws IOException {
         if (executor != null && allowConcurrentIO && !streamWrite) {
             // async execution races against the InputStream closed in the caller. Read all data locally.
-            InputStream capturedStream = streamToReentrantStream(blobName, in, blobSize, true);
+            InputStream capturedStream = streamToReentrantStream(blobName, in, blobSize, true, false);
 
             Future<Void> task = executor.submit(() -> {
                 internalWriteBlob(blobName, capturedStream, blobSize, failIfAlreadyExists);
@@ -374,7 +390,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
 
 
     /**
-     * Read object entirely into memory and check its etag.
+     * Read object entirely into memory and check its etag. Elementary read operations are timed.
      * @param objectName full path to the object
      * @param rawInputStream server input stream
      * @param size size hint, do not trust it
@@ -386,7 +402,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                                                 InputStream rawInputStream,
                                                 long size,
                                                 String objectEtag) throws IOException {
-        InputStream objectStream = streamToReentrantStream(objectName, rawInputStream, size, false);
+        InputStream objectStream = streamToReentrantStream(objectName, rawInputStream, size, false, true);
         String dataEtag = DigestUtils.md5Hex(objectStream);
 
         if (dataEtag.equalsIgnoreCase(objectEtag)) {
@@ -407,13 +423,15 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
      * @param in server input stream
      * @param sizeHint size hint, do not trust it
      * @param forceRead force reading into memory
+     * @param useReadTimeout should read be timed? (only if actual I/O is happening, not memory duplication)
      * @return re-entrant stream holding the blob
      * @throws IOException on I/O error
      */
     private InputStream streamToReentrantStream(String objectName,
                                                 InputStream in,
                                                 long sizeHint,
-                                                boolean forceRead) throws IOException {
+                                                boolean forceRead,
+                                                boolean useReadTimeout) throws IOException {
         if (!forceRead && in.markSupported()) {
             logger.debug("Reusing reentrant stream of class [" + in.getClass().getName() + "]");
             return in;
@@ -422,7 +440,6 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
 
         final int bufferSize = (int) blobStore.getBufferSizeInBytes();
         final byte[] buffer = new byte[bufferSize];
-        int read;
         ByteArrayOutputStream baos = new ByteArrayOutputStream(sizeHint > 0 ? (int) sizeHint : bufferSize) {
             @Override
             public synchronized byte[] toByteArray() {
@@ -430,7 +447,8 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
             }
         };
 
-        while ((read = in.read(buffer)) != -1) {
+        int read;
+        while ((read = useReadTimeout ? readWithTimeout(in, buffer) : in.read(buffer)) != -1) {
             baos.write(buffer, 0, read);
         }
 
@@ -441,6 +459,19 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                     "] bytes instead of [" + sizeHint + "]");
         }
         return new ByteArrayInputStream(bytesRead);
+    }
+
+    private int readWithTimeout(InputStream in, final byte[] buffer) throws IOException {
+        try {
+            return withTimeout().timeout(shortOperationTimeoutS, TimeUnit.SECONDS, () ->
+                    SwiftPerms.execThrows(() -> in.read(buffer)));
+        }
+        catch (IOException e){
+            throw e;
+        }
+        catch(Exception e){
+            throw new BlobStoreException("stream read failed", e);
+        }
     }
 
     private void internalWriteBlob(String blobName, InputStream fromStream, long blobSize, boolean failIfAlreadyExists) throws IOException {

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -385,7 +385,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                                                 InputStream rawInputStream,
                                                 long size,
                                                 String objectEtag) throws IOException {
-        InputStream objectStream = streamToReentrantStream(objectName, rawInputStream, size);
+        InputStream objectStream = streamToReentrantStream(objectName, rawInputStream, size, false);
         String dataEtag = DigestUtils.md5Hex(objectStream);
 
         if (dataEtag.equalsIgnoreCase(objectEtag)) {
@@ -397,10 +397,6 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
                 "] does not match calculated etag [" + dataEtag + "]";
         logger.warn(message);
         throw new IOException(message);
-    }
-
-    private InputStream streamToReentrantStream(String objectName, InputStream in, long sizeHint) throws IOException {
-        return streamToReentrantStream(objectName, in, sizeHint, false);
     }
 
     /**

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -425,9 +425,9 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         }
         return new InputStreamWrapperWithDataHash(objectName, object.stream, object.tag){
             @Override
-            protected int innerRead(byte[] b, int off, int len) {
+            protected int innerRead(byte[] b) {
                 try {
-                    return withTimeout().timeout(shortOperationTimeoutS, TimeUnit.SECONDS, () -> super.innerRead(b, off, len));
+                    return withTimeout().timeout(shortOperationTimeoutS, TimeUnit.SECONDS, () -> super.innerRead(b));
                 } catch (Exception e) {
                     throw new BlobStoreException("failure reading from [" + objectName + "]", e);
                 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/blobstore/SwiftBlobContainer.java
@@ -373,14 +373,14 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         internalWriteBlob(blobName, in, failIfAlreadyExists);
     }
 
-    private InputStream toReentrantStream(String blobName, InputStream in, long sizeHint) throws IOException {
+    private InputStream toReentrantStream(final String blobName, InputStream in, final long sizeHint) throws IOException {
         if (in.markSupported()) {
             logger.debug("Reusing reentrant stream of class [" + in.getClass().getName() + "]");
             return in;
         }
         logger.debug("Reading blob ["+ blobName +"], expected size ["+ sizeHint + "] bytes");
 
-        int bufferSize = (int) blobStore.getBufferSizeInBytes();
+        final int bufferSize = (int) blobStore.getBufferSizeInBytes();
         final byte[] buffer = new byte[bufferSize];
         long totalBytesRead = 0;
         int read;
@@ -394,7 +394,7 @@ public class SwiftBlobContainer extends AbstractBlobContainer {
         while ((read = in.read(buffer)) != -1) {
             totalBytesRead += read;
             if (sizeHint > 0 && totalBytesRead > sizeHint){
-                logger.warn("Exceeded expected allocation : [" + blobName + "], totalBytesRead [" + "] instead of [" + sizeHint + "]");
+                logger.warn("Exceeded expected allocation : [" + blobName + "], totalBytesRead [" + totalBytesRead + "] instead of [" + sizeHint + "]");
             }
             baos.write(buffer, 0, read);
         }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeout.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeout.java
@@ -24,11 +24,9 @@ import java.util.concurrent.TimeUnit;
 public interface WithTimeout {
     <T> T retry(long interval, long timeout, TimeUnit timeUnit, Callable<T> callable) throws Exception;
 
-    void retry(long interval, long timeout, TimeUnit timeUnit, Runnable runnable) throws Exception;
+    <T> T retry(long interval, TimeUnit timeUnit, int attempts, Callable<T> callable) throws Exception;
 
     <T> T timeout(long timeout, TimeUnit timeUnit, Callable<T> callable) throws Exception;
-
-    void timeout(long timeout, TimeUnit timeUnit, Runnable runnable) throws Exception;
 
     class Factory {
         public WithTimeout from(ThreadPool threadPool){

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeout.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeout.java
@@ -26,6 +26,10 @@ public interface WithTimeout {
 
     void retry(long interval, long timeout, TimeUnit timeUnit, Runnable runnable) throws Exception;
 
+    <T> T timeout(long timeout, TimeUnit timeUnit, Callable<T> callable) throws Exception;
+
+    void timeout(long timeout, TimeUnit timeUnit, Runnable runnable) throws Exception;
+
     class Factory {
         public WithTimeout from(ThreadPool threadPool){
             if (threadPool == null){

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutDirectImpl.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutDirectImpl.java
@@ -32,4 +32,14 @@ class WithTimeoutDirectImpl implements WithTimeout {
     public void retry(long interval, long timeout, TimeUnit timeUnit, Runnable runnable) {
         runnable.run();
     }
+
+    @Override
+    public <T> T timeout(long timeout, TimeUnit timeUnit, Callable<T> callable) throws Exception {
+        return callable.call();
+    }
+
+    @Override
+    public void timeout(long timeout, TimeUnit timeUnit, Runnable runnable) {
+        runnable.run();
+    }
 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutDirectImpl.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutDirectImpl.java
@@ -29,8 +29,8 @@ class WithTimeoutDirectImpl implements WithTimeout {
     }
 
     @Override
-    public void retry(long interval, long timeout, TimeUnit timeUnit, Runnable runnable) {
-        runnable.run();
+    public <T> T retry(long interval, TimeUnit timeUnit, int attempts, Callable<T> callable) throws Exception {
+        return callable.call();
     }
 
     @Override
@@ -38,8 +38,4 @@ class WithTimeoutDirectImpl implements WithTimeout {
         return callable.call();
     }
 
-    @Override
-    public void timeout(long timeout, TimeUnit timeUnit, Runnable runnable) {
-        runnable.run();
-    }
 }

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutExecutorImpl.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/retry/WithTimeoutExecutorImpl.java
@@ -39,26 +39,29 @@ class WithTimeoutExecutorImpl implements WithTimeout {
     }
 
     @Override
-    public void retry(long interval, long timeout, TimeUnit timeUnit, Runnable runnable)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        Future<Void> task = executorService.submit(() -> internalRetry(interval, timeout, timeUnit, () -> {runnable.run();
-                                                                                                           return null;}));
-        task.get(timeout, timeUnit);
+    public <T> T retry(long interval, TimeUnit timeUnit, int attempts, Callable<T> callable) throws Exception {
+        final long sleepMillis = TimeUnit.MILLISECONDS.convert(interval, timeUnit);
+        final int sleepNanos = (int)(TimeUnit.NANOSECONDS.convert(interval, timeUnit) - sleepMillis * 1_000_000);
+
+        for (int i = 0; i < attempts; i++) {
+            try{
+                return callable.call();
+            }
+            catch (InterruptedException e){
+                throw e;
+            }
+            catch (Exception e){
+                Thread.sleep(sleepMillis, sleepNanos);
+            }
+        }
+
+        throw new TimeoutException("retry count exhausted");
     }
 
     @Override
     public <T> T timeout(long timeout, TimeUnit timeUnit, Callable<T> callable) throws Exception {
         Future<T> task = executorService.submit(callable);
         return task.get(timeout, timeUnit);
-    }
-
-    @Override
-    public void timeout(long timeout, TimeUnit timeUnit, Runnable runnable) throws Exception {
-        Future<Void> task = executorService.submit(() -> {
-            runnable.run();
-            return null;
-        });
-        task.get(timeout, timeUnit);
     }
 
     private <T> T internalRetry(long interval, long timeout, TimeUnit timeUnit, Callable<T> callable)

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWithDataHash.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWithDataHash.java
@@ -1,0 +1,57 @@
+package org.wikimedia.elasticsearch.swift.util.stream;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.util.function.BiFunction;
+
+public class InputStreamWithDataHash extends InputStream {
+    private final InputStream innerStream;
+    private final String dataHash;
+    private String actualHash;
+    private final BiFunction<String, String, Void> onHashMismatch;
+    private final MessageDigest digest;
+    private boolean isEof = false;
+
+    public InputStreamWithDataHash(InputStream innerStream, String dataHash) {
+        this.innerStream = innerStream;
+        this.dataHash = dataHash;
+        onHashMismatch = null;
+        digest = DigestUtils.getMd5Digest();
+    }
+
+    public InputStreamWithDataHash(InputStream innerStream, String dataHash, BiFunction<String, String, Void> onHashMismatch) {
+        this.innerStream = innerStream;
+        this.dataHash = dataHash;
+        this.onHashMismatch = onHashMismatch;
+        digest = DigestUtils.getMd5Digest();
+    }
+
+    @Override
+    public int read() throws IOException {
+        final int result = innerStream.read();
+        if (result >= 0){
+            digest.update((byte) result);
+            return result;
+        }
+
+        if (!isEof) {
+            isEof = true;
+            actualHash = Hex.encodeHexString(digest.digest());
+        }
+
+        if (!dataHash.equalsIgnoreCase(actualHash)){
+            if (onHashMismatch != null){
+                onHashMismatch.apply(dataHash, actualHash);
+            }
+            else {
+                throw new IOException("Mismatched hash on stream data, expected [" + dataHash + "], actual [" + actualHash + "]");
+            }
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWrapperWithDataHash.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWrapperWithDataHash.java
@@ -9,6 +9,7 @@ import java.security.MessageDigest;
 import java.util.function.BiFunction;
 
 public class InputStreamWrapperWithDataHash extends InputStream {
+    private final String objectName;
     private final InputStream innerStream;
     private final String dataHash;
     private String actualDataHash;
@@ -16,13 +17,15 @@ public class InputStreamWrapperWithDataHash extends InputStream {
     private final MessageDigest digest = DigestUtils.getMd5Digest();
     private boolean isEof = false;
 
-    public InputStreamWrapperWithDataHash(InputStream innerStream, String dataHash) {
+    public InputStreamWrapperWithDataHash(String objectName, InputStream innerStream, String dataHash) {
+        this.objectName = objectName;
         this.innerStream = innerStream;
         this.dataHash = dataHash;
         onHashMismatch = null;
     }
 
-    public InputStreamWrapperWithDataHash(InputStream innerStream, String dataHash, BiFunction<String, String, Void> onHashMismatch) {
+    public InputStreamWrapperWithDataHash(String objectName, InputStream innerStream, String dataHash, BiFunction<String, String, Void> onHashMismatch) {
+        this.objectName = objectName;
         this.innerStream = innerStream;
         this.dataHash = dataHash;
         this.onHashMismatch = onHashMismatch;
@@ -46,7 +49,7 @@ public class InputStreamWrapperWithDataHash extends InputStream {
                 onHashMismatch.apply(dataHash, actualDataHash);
             }
             else {
-                throw new IOException("Mismatched hash on stream data, expected [" + dataHash + "], actual [" + actualDataHash + "]");
+                throw new IOException("Mismatched hash on stream for [" + objectName + "], expected [" + dataHash + "], actual [" + actualDataHash + "]");
             }
         }
 

--- a/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWrapperWithDataHash.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/util/stream/InputStreamWrapperWithDataHash.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Wikimedia and BigData Boutique
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.wikimedia.elasticsearch.swift.util.stream;
 
 import org.apache.commons.codec.binary.Hex;
@@ -24,7 +40,8 @@ public class InputStreamWrapperWithDataHash extends InputStream {
         onHashMismatch = null;
     }
 
-    public InputStreamWrapperWithDataHash(String objectName, InputStream innerStream, String dataHash, BiFunction<String, String, Void> onHashMismatch) {
+    public InputStreamWrapperWithDataHash(String objectName, InputStream innerStream, String dataHash,
+                                          BiFunction<String, String, Void> onHashMismatch) {
         this.objectName = objectName;
         this.innerStream = innerStream;
         this.dataHash = dataHash;
@@ -49,7 +66,8 @@ public class InputStreamWrapperWithDataHash extends InputStream {
                 onHashMismatch.apply(dataHash, actualDataHash);
             }
             else {
-                throw new IOException("Mismatched hash on stream for [" + objectName + "], expected [" + dataHash + "], actual [" + actualDataHash + "]");
+                throw new IOException("Mismatched hash on stream for [" + objectName + "], expected [" + dataHash +
+                                      "], actual [" + actualDataHash + "]");
             }
         }
 


### PR DESCRIPTION
This code contains two improvements.

New options stream_read(true by default) and stream_write(false by default) have been introduced. When set to true, memory footprint is reduced, and when set to false, unreliable Swift I/O operations can be retried.

The second improvement, mutable in-memory streams, halves memory use when it is being allocated aggressively.